### PR TITLE
Switch const -> var

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function addGroup(resource, actionTypes, group) {
 }
 
 module.exports = function(resource) {
-  const actionTypes = {};
+  var actionTypes = {};
 
   addGroup(resource, actionTypes, 'fetch');
   addGroup(resource, actionTypes, 'create');


### PR DESCRIPTION
I'm assuming this is just a mistake - it's resulting in `const` appearing in redux-crud bundled output unless you run babel on your entire node_modules tree, which judging by the rest of the redux-crud codebase I don't think is the intention?
